### PR TITLE
make `check_instance()` default to `True` for unhandled generic types

### DIFF
--- a/hamilton/htypes.py
+++ b/hamilton/htypes.py
@@ -381,5 +381,12 @@ def check_instance(obj: Any, type_: Any) -> bool:
                         return False
                 return True
 
+            else:
+                # other generics are not currently supported, but
+                # return `True` here because otherwise the type will
+                # be treated liked a non-generic type and probably
+                # cause an error.
+                return True
+
     # If the type is not a generic type, just use isinstance
     return isinstance(obj, type_)


### PR DESCRIPTION
If a type annotation is a generic, but not a dict, list, tuple, or set, the `check_instance()` function ends up calling `isinstance(obj, type_)`. This causes an error for other generic types. For instance, when using `numpy.typing`, the type NDArray[np.float_])` results in the following exception:

`TypeError: isinstance() argument 2 cannot be a parameterized generic`.

This change at least avoids that error, but it defaults to always returning `True`, which does not check any of the element types. So the type checking is incomplete. However, unless Hamilton wants to implement a full type checker, that's probably unavoidable.

For full runtime type checking, it probably makes more sense to use something like typeguard or jaxtyping.

## Changes

Simply return `True` instead of calling `isinstance(obj, type_)` when `type_` is a parameterized generic.

## How I tested this

Ran through a pipeline with `numpy.typing` type annotations, which were causing a `TypeError`.

## Notes

Type checking is incomplete. Perhaps there should be a warning when hitting this code path?

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
